### PR TITLE
Demo PR for Showcasing Issue Comments Threading

### DIFF
--- a/cmd/pullpo/main.go
+++ b/cmd/pullpo/main.go
@@ -12,20 +12,11 @@ import (
 	"strings"
 	"time"
 
-	surveyCore "github.com/AlecAivazis/survey/v2/core"
-	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/build"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/update"
-	"github.com/cli/cli/v2/pkg/cmd/factory"
-	"github.com/cli/cli/v2/pkg/cmd/root"
 	"github.com/cli/cli/v2/pkg/cmdutil"
-	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/cli/v2/utils"
 	"github.com/cli/safeexec"
 	"github.com/mattn/go-isatty"
-	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
 )
 
@@ -46,149 +37,7 @@ func main() {
 	os.Exit(int(code))
 }
 
-func mainRun() exitCode {
-	buildDate := build.Date
-	buildVersion := build.Version
-	hasDebug, _ := utils.IsDebugEnabled()
-
-	cmdFactory := factory.New(buildVersion)
-	stderr := cmdFactory.IOStreams.ErrOut
-
-	ctx := context.Background()
-
-	updateCtx, updateCancel := context.WithCancel(ctx)
-	defer updateCancel()
-	updateMessageChan := make(chan *update.ReleaseInfo)
-	go func() {
-		rel, err := checkForUpdate(updateCtx, cmdFactory, buildVersion)
-		if err != nil && hasDebug {
-			fmt.Fprintf(stderr, "warning: checking for update failed: %v", err)
-		}
-		updateMessageChan <- rel
-	}()
-
-	if !cmdFactory.IOStreams.ColorEnabled() {
-		surveyCore.DisableColor = true
-		ansi.DisableColors(true)
-	} else {
-		// override survey's poor choice of color
-		surveyCore.TemplateFuncsWithColor["color"] = func(style string) string {
-			switch style {
-			case "white":
-				return ansi.ColorCode("default")
-			default:
-				return ansi.ColorCode(style)
-			}
-		}
-	}
-
-	// Enable running pullpo from Windows File Explorer's address bar. Without this, the user is told to stop and run from a
-	// terminal. With this, a user can clone a repo (or take other actions) directly from explorer.
-	if len(os.Args) > 1 && os.Args[1] != "" {
-		cobra.MousetrapHelpText = ""
-	}
-
-	rootCmd, err := root.NewCmdRoot(cmdFactory, buildVersion, buildDate)
-	if err != nil {
-		fmt.Fprintf(stderr, "failed to create root command: %s\n", err)
-		return exitError
-	}
-
-	expandedArgs := []string{}
-	if len(os.Args) > 0 {
-		expandedArgs = os.Args[1:]
-	}
-
-	// translate `pullpo help <command>` to `pullpo <command> --help` for extensions.
-	if len(expandedArgs) >= 2 && expandedArgs[0] == "help" && isExtensionCommand(rootCmd, expandedArgs[1:]) {
-		expandedArgs = expandedArgs[1:]
-		expandedArgs = append(expandedArgs, "--help")
-	}
-
-	rootCmd.SetArgs(expandedArgs)
-
-	if cmd, err := rootCmd.ExecuteContextC(ctx); err != nil {
-		var pagerPipeError *iostreams.ErrClosedPagerPipe
-		var noResultsError cmdutil.NoResultsError
-		var extError *root.ExternalCommandExitError
-		var authError *root.AuthError
-		if err == cmdutil.SilentError {
-			return exitError
-		} else if err == cmdutil.PendingError {
-			return exitPending
-		} else if cmdutil.IsUserCancellation(err) {
-			if errors.Is(err, terminal.InterruptErr) {
-				// ensure the next shell prompt will start on its own line
-				fmt.Fprint(stderr, "\n")
-			}
-			return exitCancel
-		} else if errors.As(err, &authError) {
-			return exitAuth
-		} else if errors.As(err, &pagerPipeError) {
-			// ignore the error raised when piping to a closed pager
-			return exitOK
-		} else if errors.As(err, &noResultsError) {
-			if cmdFactory.IOStreams.IsStdoutTTY() {
-				fmt.Fprintln(stderr, noResultsError.Error())
-			}
-			// no results is not a command failure
-			return exitOK
-		} else if errors.As(err, &extError) {
-			// pass on exit codes from extensions and shell aliases
-			return exitCode(extError.ExitCode())
-		}
-
-		printError(stderr, err, cmd, hasDebug)
-
-		if strings.Contains(err.Error(), "Incorrect function") {
-			fmt.Fprintln(stderr, "You appear to be running in MinTTY without pseudo terminal support.")
-			fmt.Fprintln(stderr, "To learn about workarounds for this error, run:  pullpo help mintty")
-			return exitError
-		}
-
-		var httpErr api.HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 401 {
-			fmt.Fprintln(stderr, "Try authenticating with:  pullpo auth login")
-		} else if u := factory.SSOURL(); u != "" {
-			// handles organization SAML enforcement error
-			fmt.Fprintf(stderr, "Authorize in your web browser:  %s\n", u)
-		} else if msg := httpErr.ScopesSuggestion(); msg != "" {
-			fmt.Fprintln(stderr, msg)
-		}
-
-		return exitError
-	}
-	if root.HasFailed() {
-		return exitError
-	}
-
-	updateCancel() // if the update checker hasn't completed by now, abort it
-	newRelease := <-updateMessageChan
-	if newRelease != nil {
-		isHomebrew := isUnderHomebrew(cmdFactory.Executable())
-		if isHomebrew && isRecentRelease(newRelease.PublishedAt) {
-			// do not notify Homebrew users before the version bump had a chance to get merged into homebrew-core
-			return exitOK
-		}
-		fmt.Fprintf(stderr, "\n\n%s %s → %s\n",
-			ansi.Color("A new release of pullpo is available:", "yellow"),
-			ansi.Color(strings.TrimPrefix(buildVersion, "v"), "cyan"),
-			ansi.Color(strings.TrimPrefix(newRelease.Version, "v"), "cyan"))
-		if isHomebrew {
-			fmt.Fprintf(stderr, "To upgrade, run: %s\n", "brew upgrade gh")
-		}
-		fmt.Fprintf(stderr, "%s\n\n",
-			ansi.Color(newRelease.URL, "yellow"))
-	}
-
-	return exitOK
-}
-
 // isExtensionCommand returns true if args resolve to an extension command.
-func isExtensionCommand(rootCmd *cobra.Command, args []string) bool {
-	c, _, err := rootCmd.Find(args)
-	return err == nil && c != nil && c.GroupID == "extension"
-}
 
 func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 	var dnsError *net.DNSError

--- a/pkg/extensions/extension_mock.go
+++ b/pkg/extensions/extension_mock.go
@@ -3,14 +3,6 @@
 
 package extensions
 
-import (
-	"sync"
-)
-
-// Ensure, that ExtensionMock does implement Extension.
-// If this is not the case, regenerate this file with moq.
-var _ Extension = &ExtensionMock{}
-
 // ExtensionMock is a mock implementation of Extension.
 //
 //	func TestSomethingThatUsesExtension(t *testing.T) {
@@ -53,81 +45,6 @@ var _ Extension = &ExtensionMock{}
 //		// and then make assertions.
 //
 //	}
-type ExtensionMock struct {
-	// CurrentVersionFunc mocks the CurrentVersion method.
-	CurrentVersionFunc func() string
-
-	// IsBinaryFunc mocks the IsBinary method.
-	IsBinaryFunc func() bool
-
-	// IsLocalFunc mocks the IsLocal method.
-	IsLocalFunc func() bool
-
-	// IsPinnedFunc mocks the IsPinned method.
-	IsPinnedFunc func() bool
-
-	// LatestVersionFunc mocks the LatestVersion method.
-	LatestVersionFunc func() string
-
-	// NameFunc mocks the Name method.
-	NameFunc func() string
-
-	// OwnerFunc mocks the Owner method.
-	OwnerFunc func() string
-
-	// PathFunc mocks the Path method.
-	PathFunc func() string
-
-	// URLFunc mocks the URL method.
-	URLFunc func() string
-
-	// UpdateAvailableFunc mocks the UpdateAvailable method.
-	UpdateAvailableFunc func() bool
-
-	// calls tracks calls to the methods.
-	calls struct {
-		// CurrentVersion holds details about calls to the CurrentVersion method.
-		CurrentVersion []struct {
-		}
-		// IsBinary holds details about calls to the IsBinary method.
-		IsBinary []struct {
-		}
-		// IsLocal holds details about calls to the IsLocal method.
-		IsLocal []struct {
-		}
-		// IsPinned holds details about calls to the IsPinned method.
-		IsPinned []struct {
-		}
-		// LatestVersion holds details about calls to the LatestVersion method.
-		LatestVersion []struct {
-		}
-		// Name holds details about calls to the Name method.
-		Name []struct {
-		}
-		// Owner holds details about calls to the Owner method.
-		Owner []struct {
-		}
-		// Path holds details about calls to the Path method.
-		Path []struct {
-		}
-		// URL holds details about calls to the URL method.
-		URL []struct {
-		}
-		// UpdateAvailable holds details about calls to the UpdateAvailable method.
-		UpdateAvailable []struct {
-		}
-	}
-	lockCurrentVersion  sync.RWMutex
-	lockIsBinary        sync.RWMutex
-	lockIsLocal         sync.RWMutex
-	lockIsPinned        sync.RWMutex
-	lockLatestVersion   sync.RWMutex
-	lockName            sync.RWMutex
-	lockOwner           sync.RWMutex
-	lockPath            sync.RWMutex
-	lockURL             sync.RWMutex
-	lockUpdateAvailable sync.RWMutex
-}
 
 // CurrentVersion calls CurrentVersionFunc.
 func (mock *ExtensionMock) CurrentVersion() string {


### PR DESCRIPTION
## Useful links: 

- [Pullpo Slack PR Channels.](https://pullpo.io/products/channels)
- [GitHub Issue threading docs. ](https://docs.pullpo.io/channels-full-sync)

## The problem 
By default, GitHub doesn't allow threaded messages in PR issue comments. This has been a pain for many people for a long time: 

- https://github.com/orgs/community/discussions/8469
- https://github.com/orgs/community/discussions/5633

This means that some Pullpo functionality, like full bidirectionality (sending all Slack PR Channels messages back to GitHub), may not be showcased optimally. This doesn't occur with GitLab and Bitbucket (which we also integrate, by the way).

## Before and After
Thanks to [.github/workflows/pullpo.yml ](https://github.com/pullpo-io/cli/blob/main/.github/pullpo.yaml) and the [Pullpo app](https://github.com/marketplace/pullpo-for-slack), when someone creates an issue comment on a GitHub PR (or even in its PR Slack channel), the Pullpo app will take that message and transform it into a file comment message referencing a newly created file called `pr_${{ github.event.pull_request.number }}_threads.txt`.

### Before
![image](https://github.com/pullpo-io/cli/assets/44880660/e11c2c5e-66d1-4e57-969b-88a8c60d48ab)
### After 
![image](https://github.com/pullpo-io/cli/assets/44880660/6a2b04c0-414d-402e-b01e-3a3ef2d16631)

## Why a GitHub action is necessary and not just a GitHub app.
This GitHub action requires write access to your code, since the Pullpo app is not Open Source, we thought that it would be better if you could see how exactly we are using that permission.

## Is the new created file going to generate merge conflicts?
No never. The GitHub Action in charge of setting up the -pullpo- directory, which allows threaded conversations, produces a distinct file for each new pull request. As the file created for your pull request has its own unique name and is not present in any other pull request, there's no chance of encountering a merge conflict due to Pullpo's threaded conversations workflow.

## How does it work?
This GitHub Action, named "Pullpo PR Threads," runs whenever a pull request is opened. This action requires write permissions, thats why we created an action, so that you can see exactly what it does.

Here's what it does:

When a pull request is opened, it creates a special folder called 一pullpo一 if it doesn't already exist. We named it this way so that it always appears at the end of the files changed tab. Inside this folder, a simple text file is created to track discussions related to this specific pull request. Based on how it works, these files will never create merge conflicts.

Then when someone creates an issue comment on GitHub (or in a PR Slack channel), the Pullpo app is going to take that message and transform it into a file comment message referencing this newly created file.

Basically, this action sets up a spot for threaded conversations linked to pull requests. It helps the Pullpo app to organize comments more neatly.

## Installation
### Install Pullpo in your GitHub org or individual account.
 First, you will need to install Pullpo in your GitHub account. Installing the Pullpo Slack integration is not necessary for issue threading, but it's recommended. Read more about the installation process [here](https://docs.pullpo.io/installation).

### Add GitHub action (runs in 10s)
In every repo where you want to enable GitHub PR issue threads you need to add this [10s GitHub action](https://github.com/pullpo-io/cli/blob/main/.github/pullpo.yaml).

###  (Optional) Enable PR Slack Channels with full bidirectionality.
To get the most out of Pullpo, enable full sync with PR Slack channels. After [installing our Slack integration](https://docs.pullpo.io/installation#install-on-a-workspace) and [synchronizing your devs](https://pullpo.io/app/people), you can enable full-sync mode in your [Pullpo settings](https://pullpo.io/app/settings).


# Try it yourself by generating an issue comment in this PR! Have fun! 😊




