### PR TITLE
Demo PR for Showcasing Issue Comments Threading

### DIFF
--- a/cmd/pullpo/main.go
+++ b/cmd/pullpo/main.go
@@ -71,14 +71,7 @@ func mainRun() exitCode {
 		surveyCore.DisableColor = true
 		ansi.DisableColors(true)
 	} else {
-		// override survey's poor choice of color
-		surveyCore.TemplateFuncsWithColor["color"] = func(style string) string {
-			switch style {
-			case "white":
-				return ansi.ColorCode("default")
-			default:
-				return ansi.ColorCode(style)
-			}
+
 		}
 	}
 

--- a/pkg/extensions/extension_mock.go
+++ b/pkg/extensions/extension_mock.go
@@ -54,8 +54,7 @@ var _ Extension = &ExtensionMock{}
 //
 //	}
 type ExtensionMock struct {
-	// CurrentVersionFunc mocks the CurrentVersion method.
-	CurrentVersionFunc func() string
+
 
 	// IsBinaryFunc mocks the IsBinary method.
 	IsBinaryFunc func() bool

--- a/pkg/jsoncolor/jsoncolor.go
+++ b/pkg/jsoncolor/jsoncolor.go
@@ -9,11 +9,9 @@ import (
 )
 
 const (
-	colorDelim  = "1;38" // bright white
-	colorKey    = "1;34" // bright blue
-	colorNull   = "36"   // cyan
-	colorString = "32"   // green
-	colorBool   = "33"   // yellow
+	colorDelim = "1;38" // bright white
+	colorKey   = "1;34" // bright blue
+
 )
 
 // Write colorized JSON output parsed from reader

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,7 +9,6 @@ import (
 
 func IsDebugEnabled() (bool, string) {
 	debugValue, isDebugSet := os.LookupEnv("GH_DEBUG")
-	legacyDebugValue := os.Getenv("DEBUG")
 
 	if !isDebugSet {
 		switch legacyDebugValue {


### PR DESCRIPTION
## Useful links: 

- [Pullpo Slack PR Channels.](https://pullpo.io/products/channels)
- [GitHub Issue threads docs. ](https://docs.pullpo.io/channels-full-sync)

## The problem 
By default, GitHub doesn't allow threaded messages in PR issue comments. This has been a pain for many people for a long time: 

- https://github.com/orgs/community/discussions/8469
- https://github.com/orgs/community/discussions/5633

This means that some Pullpo functionality, like full bidirectionality (sending all Slack PR Channels messages back to GitHub), may not be showcased optimally. This doesn't occur with GitLab and Bitbucket (which we also integrate, by the way).

## Before and After
Thanks to [.github/workflows/pullpo.yml ](https://github.com/pullpo-io/cli/blob/main/.github/pullpo.yaml) and the [Pullpo app](https://github.com/marketplace/pullpo-for-slack), when someone creates an issue comment on a GitHub PR (or even in its PR Slack channel), the Pullpo app will take that message and transform it into a file comment message referencing a newly created file called `pr_${{ github.event.pull_request.number }}_threads.txt`.

### Before
![image](https://github.com/pullpo-io/cli/assets/44880660/e11c2c5e-66d1-4e57-969b-88a8c60d48ab)
### After 
![image](https://github.com/pullpo-io/cli/assets/44880660/6a2b04c0-414d-402e-b01e-3a3ef2d16631)

## Why a GitHub action is necessary and not just a GitHub app.
This GitHub action requires write access to your code, since the Pullpo app is not Open Source, we thought that it would be better if you could see how exactly we are using that permission.

## Is the new created file going to generate merge conflicts?
No never. The GitHub Action in charge of setting up the -pullpo- directory, which allows threaded conversations, produces a distinct file for each new pull request. As the file created for your pull request has its own unique name and is not present in any other pull request, there's no chance of encountering a merge conflict due to Pullpo's threaded conversations workflow.

## How does it work?
This GitHub Action, named "Pullpo PR Threads," runs whenever a pull request is opened. This action requires write permissions, thats why we created an action, so that you can see exactly what it does.

Here's what it does:

When a pull request is opened, it creates a special folder called 一pullpo一 if it doesn't already exist. We named it this way so that it always appears at the end of the files changed tab. Inside this folder, a simple text file is created to track discussions related to this specific pull request. Based on how it works, these files will never create merge conflicts.

Then when someone creates an issue comment on GitHub (or in a PR Slack channel), the Pullpo app is going to take that message and transform it into a file comment message referencing this newly created file.

Basically, this action sets up a spot for threaded conversations linked to pull requests. It helps the Pullpo app to organize comments more neatly.

## Installation
### Install Pullpo in your GitHub org or individual account.
 First, you will need to install Pullpo in your GitHub account. Installing the Pullpo Slack integration is not necessary for issue threading, but it's recommended. Read more about the installation process [here](https://docs.pullpo.io/installation).

### Add GitHub action (runs in 10s)
In every repo where you want to enable GitHub PR issue threads you need to add this [10s GitHub action](https://github.com/pullpo-io/cli/blob/main/.github/pullpo.yaml).

###  (Optional) Enable PR Slack Channels with full bidirectionality.
To get the most out of Pullpo, enable full sync with PR Slack channels. After [installing our Slack integration](https://docs.pullpo.io/installation#install-on-a-workspace) and [synchronizing your devs](https://pullpo.io/app/people), you can enable full-sync mode in your [Pullpo settings](https://pullpo.io/app/settings).


# Try it yourself by generating an issue comment in this PR! Have fun! 😊




